### PR TITLE
Throw a PavlovaParsingError with context information on parsing errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 
 Added support for using Pavlova with Flask
 Added support for Python 3.6
+Added PavlovaParsingError, which is thrown when a ValueError or TypeError is
+    raised while parsing
 
 0.1.0 (2018-02-22)
 ++++++++++++++++++

--- a/pavlova/base.py
+++ b/pavlova/base.py
@@ -1,7 +1,7 @@
 "The abstract class for the Pavlova class"
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Type, TypeVar
+from typing import Any, Type, TypeVar, Mapping, Optional, Tuple
 
 T = TypeVar('T')  # pylint: disable=invalid-name
 
@@ -10,12 +10,16 @@ class BasePavlova(ABC):
     "The base pavlova class. Use the pavlova.Pavlova class instead"
     @abstractmethod
     def from_mapping(self,
-                     input_mapping: Dict[Any, Any],
-                     model_class: Type[T]) -> T:
+                     input_mapping: Mapping[Any, Any],
+                     model_class: Type[T],
+                     path: Optional[Tuple[str, ...]] = None) -> T:
         "Parse from a Mapping and return a model_class"
         pass
 
     @abstractmethod
-    def parse_field(self, input_value: Any, field_type: Type) -> Any:
+    def parse_field(self,
+                    input_value: Any,
+                    field_type: Type,
+                    path: Tuple[str, ...]) -> Any:
         "Parse a particular field with type field_type"
         pass

--- a/pavlova/parsers.py
+++ b/pavlova/parsers.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 import datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Any, List, Dict, Union, Type, TypeVar, Generic
+from typing import Any, List, Dict, Union, Type, TypeVar, Generic, Tuple
 
 import dateparser
 
@@ -23,7 +23,10 @@ class PavlovaParser(Generic[T], ABC):
         self.pavlova = pavlova_instance
 
     @abstractmethod
-    def parse_input(self, input_value: Any, field_type: Type) -> T:
+    def parse_input(self,
+                    input_value: Any,
+                    field_type: Type,
+                    path: Tuple[str, ...]) -> T:
         "Given an input, return it's typed value"
         pass
 
@@ -31,7 +34,10 @@ class PavlovaParser(Generic[T], ABC):
 class BoolParser(PavlovaParser[bool]):
     "Parses a Boolean"
 
-    def parse_input(self, input_value: Any, field_type: Type) -> bool:
+    def parse_input(self,
+                    input_value: Any,
+                    field_type: Type,
+                    path: Tuple[str, ...]) -> bool:
         if isinstance(input_value, str):
             input_string = input_value.lower()
             if input_string in ('yes', 'true', '1'):
@@ -47,49 +53,67 @@ class BoolParser(PavlovaParser[bool]):
 class ListParser(PavlovaParser[List[T]]):
     "Parses a List"
 
-    def parse_input(self, input_value: Any, field_type: Type) -> List[T]:
+    def parse_input(self,
+                    input_value: Any,
+                    field_type: Type,
+                    path: Tuple[str, ...]) -> List[T]:
         if not isinstance(input_value, list):
             raise TypeError(f'Input value: {input_value} is not a list')
 
         sub_type = field_type.__args__[0]
         return [
-            self.pavlova.parse_field(i, sub_type)
-            for i in input_value
+            self.pavlova.parse_field(f, sub_type, path + (f'[{i}]',))
+            for i, f in enumerate(input_value)
         ]
 
 
 class IntParser(PavlovaParser[int]):
     "Parses ints"
 
-    def parse_input(self, input_value: Any, field_type: Type) -> int:
+    def parse_input(self,
+                    input_value: Any,
+                    field_type: Type,
+                    path: Tuple[str, ...]) -> int:
         return int(input_value)
 
 
 class FloatParser(PavlovaParser[float]):
     "Parses floats"
 
-    def parse_input(self, input_value: Any, field_type: Type) -> float:
+    def parse_input(self,
+                    input_value: Any,
+                    field_type: Type,
+                    path: Tuple[str, ...]) -> float:
         return float(input_value)
 
 
 class DecimalParser(PavlovaParser[Decimal]):
     "Parses floats"
 
-    def parse_input(self, input_value: Any, field_type: Type) -> Decimal:
+    def parse_input(self,
+                    input_value: Any,
+                    field_type: Type,
+                    path: Tuple[str, ...]) -> Decimal:
         return Decimal(input_value)
 
 
 class StringParser(PavlovaParser[str]):
     "Parses a String"
 
-    def parse_input(self, input_value: Any, field_type: Type) -> str:
+    def parse_input(self,
+                    input_value: Any,
+                    field_type: Type,
+                    path: Tuple[str, ...]) -> str:
         return str(input_value)
 
 
 class DictParser(PavlovaParser[Dict]):
     "Parses a dictionary"
 
-    def parse_input(self, input_value: Any, field_type: Type) -> Dict:
+    def parse_input(self,
+                    input_value: Any,
+                    field_type: Type,
+                    path: Tuple[str, ...]) -> Dict:
         'Parses a dictionary into a typed structure'
         if not isinstance(input_value, dict):
             raise TypeError(f'Input value: {input_value} is not a dict')
@@ -97,8 +121,8 @@ class DictParser(PavlovaParser[Dict]):
         key_type = field_type.__args__[0]
         value_type = field_type.__args__[1]
         return {
-            self.pavlova.parse_field(k, key_type):
-            self.pavlova.parse_field(v, value_type)
+            self.pavlova.parse_field(k, key_type, path):
+            self.pavlova.parse_field(v, value_type, path + (k,))
             for k, v in input_value.items()
         }
 
@@ -106,8 +130,10 @@ class DictParser(PavlovaParser[Dict]):
 class DatetimeParser(PavlovaParser[datetime.datetime]):
     "Parses a datetime"
 
-    def parse_input(self, input_value: Any, field_type: Type) -> \
-            datetime.datetime:
+    def parse_input(self,
+                    input_value: Any,
+                    field_type: Type,
+                    path: Tuple[str, ...]) -> datetime.datetime:
         return dateparser.parse(input_value)
 
 
@@ -128,18 +154,24 @@ class UnionParser(PavlovaParser[Union[T]]):
 
         return True
 
-    def parse_input(self, input_value: Any, field_type: Type) -> T:
+    def parse_input(self,
+                    input_value: Any,
+                    field_type: Type,
+                    path: Tuple[str, ...]) -> T:
         if not self._is_from_optional(field_type):
             raise TypeError('Unions of this type are not allowed')
 
         real_field_type = field_type.__args__[0]
-        return self.pavlova.parse_field(input_value, real_field_type)
+        return self.pavlova.parse_field(input_value, real_field_type, path)
 
 
 class EnumParser(PavlovaParser[Enum]):
     "Parses enums"
 
-    def parse_input(self, input_value: Any, field_type: Type) -> Enum:
+    def parse_input(self,
+                    input_value: Any,
+                    field_type: Type,
+                    path: Tuple[str, ...]) -> Enum:
         # If the input is a string, try matching it against the names of the
         # enum members. For consistency, we will lower case both values first.
         if isinstance(input_value, str):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -17,7 +17,7 @@ class TestBoolParser(unittest.TestCase):
 
         input_values = ('yes', 'true', '1')
         self.assertTrue(all(
-            parser.parse_input(v, bool) for v in input_values
+            parser.parse_input(v, bool, tuple()) for v in input_values
         ))
 
     def test_falsy_string_values(self) -> None:
@@ -25,21 +25,21 @@ class TestBoolParser(unittest.TestCase):
 
         input_values = ('no', 'false', '0')
         self.assertFalse(any(
-            parser.parse_input(v, bool) for v in input_values
+            parser.parse_input(v, bool, tuple()) for v in input_values
         ))
 
     def test_non_boolean_string_raise_typeerror(self) -> None:
         parser: PavlovaParser = pavlova.parsers.BoolParser(Pavlova())
 
         with self.assertRaises(TypeError):
-            parser.parse_input('aaa', bool)
+            parser.parse_input('aaa', bool, tuple())
 
     def test_non_string_truthy_values(self) -> None:
         parser: PavlovaParser = pavlova.parsers.BoolParser(Pavlova())
 
         input_values = (1, True, 1.0)
         self.assertTrue(all(
-            parser.parse_input(v, bool) for v in input_values
+            parser.parse_input(v, bool, tuple()) for v in input_values
         ))
 
     def test_non_string_falsy_values(self) -> None:
@@ -47,7 +47,7 @@ class TestBoolParser(unittest.TestCase):
 
         input_values = (0, None, False)
         self.assertFalse(any(
-            parser.parse_input(v, bool) for v in input_values
+            parser.parse_input(v, bool, tuple()) for v in input_values
         ))
 
 
@@ -56,11 +56,11 @@ class TestListParser(unittest.TestCase):
         parser: PavlovaParser = pavlova.parsers.ListParser(Pavlova())
 
         with self.assertRaises(TypeError):
-            parser.parse_input('', List[int])
+            parser.parse_input('', List[int], tuple())
 
     def test_returns_correct_values(self) -> None:
         parser: PavlovaParser = pavlova.parsers.ListParser(Pavlova())
-        values = parser.parse_input([0, 1, 2], List[bool])
+        values = parser.parse_input([0, 1, 2], List[bool], tuple())
 
         self.assertEqual(values, [False, True, True])
 
@@ -68,14 +68,14 @@ class TestListParser(unittest.TestCase):
         parser: PavlovaParser = pavlova.parsers.ListParser(Pavlova())
 
         with self.assertRaises(TypeError):
-            parser.parse_input([0, 1, 'a'], List[bool])
+            parser.parse_input([0, 1, 'a'], List[bool], tuple())
 
 
 class TestStringParser(unittest.TestCase):
     def test_returns_string(self) -> None:
         parser: PavlovaParser = pavlova.parsers.StringParser(Pavlova())
 
-        value = parser.parse_input(False, str)
+        value = parser.parse_input(False, str, tuple())
         self.assertEqual(type(value), str)
         self.assertEqual(value, 'False')
 
@@ -85,12 +85,12 @@ class TestDictParser(unittest.TestCase):
         parser: PavlovaParser = pavlova.parsers.DictParser(Pavlova())
 
         with self.assertRaises(TypeError):
-            parser.parse_input('', Dict[str, bool])
+            parser.parse_input('', Dict[str, bool], tuple())
 
     def test_returns_correct_dictionary(self) -> None:
         parser: PavlovaParser = pavlova.parsers.DictParser(Pavlova())
 
-        value = parser.parse_input({1: 'yes'}, Dict[str, bool])
+        value = parser.parse_input({1: 'yes'}, Dict[str, bool], tuple())
         self.assertEqual(value, {'1': True})
 
 
@@ -98,7 +98,9 @@ class TestDatetimeParser(unittest.TestCase):
     def test_parses_datetime(self) -> None:
         parser: PavlovaParser = pavlova.parsers.DatetimeParser(Pavlova())
 
-        value = parser.parse_input('2018-01-02T03:10:11+03:00', datetime)
+        value = parser.parse_input(
+            '2018-01-02T03:10:11+03:00', datetime, tuple()
+        )
         self.assertEqual(value.year, 2018)
         self.assertEqual(value.month, 1)
         self.assertEqual(value.day, 2)
@@ -113,16 +115,16 @@ class TestUnionParser(unittest.TestCase):
         parser: PavlovaParser = pavlova.parsers.UnionParser(Pavlova())
 
         with self.assertRaises(TypeError):
-            parser.parse_input('', Union[str])
+            parser.parse_input('', Union[str], tuple())
 
         with self.assertRaises(TypeError):
-            parser.parse_input('', Union[str, int])
+            parser.parse_input('', Union[str, int], tuple())
 
     def test_returns_correct_values(self) -> None:
         parser: PavlovaParser = pavlova.parsers.UnionParser(Pavlova())
 
         self.assertEqual(
-            parser.parse_input('yes', Optional[bool]),
+            parser.parse_input('yes', Optional[bool], tuple()),
             True,
         )
 
@@ -131,42 +133,74 @@ class TestIntParser(unittest.TestCase):
     def test_parses_int(self) -> None:
         parser: PavlovaParser = pavlova.parsers.IntParser(Pavlova())
 
-        self.assertEqual(parser.parse_input('10', int), 10)
-        self.assertEqual(parser.parse_input(10, int), 10)
-        self.assertEqual(parser.parse_input(10.1, int), 10)
-        self.assertEqual(parser.parse_input(-10.1, int), -10)
-        self.assertEqual(parser.parse_input('-10', int), -10)
+        self.assertEqual(
+            parser.parse_input('10', int, tuple()), 10
+        )
+        self.assertEqual(
+            parser.parse_input(10, int, tuple()), 10
+        )
+        self.assertEqual(
+            parser.parse_input(10.1, int, tuple()), 10
+        )
+        self.assertEqual(
+            parser.parse_input(-10.1, int, tuple()), -10
+        )
+        self.assertEqual(parser.parse_input('-10', int, tuple()), -10)
 
     def test_doesnt_parse_string_float(self) -> None:
         parser: PavlovaParser = pavlova.parsers.IntParser(Pavlova())
 
         with self.assertRaises(Exception):
-            self.assertEqual(parser.parse_input('10.1', int), 10)
+            self.assertEqual(
+                parser.parse_input('10.1', int, tuple()), 10
+            )
 
 
 class TestFloatParser(unittest.TestCase):
     def test_parses_int(self) -> None:
         parser: PavlovaParser = pavlova.parsers.FloatParser(Pavlova())
 
-        self.assertEqual(parser.parse_input('10', float), 10.0)
-        self.assertEqual(parser.parse_input(10, float), 10.0)
-        self.assertEqual(parser.parse_input(10.1, float), 10.1)
-        self.assertEqual(parser.parse_input(-10.1, float), -10.1)
-        self.assertEqual(parser.parse_input('-10', float), -10)
-        self.assertEqual(parser.parse_input('-10.1', float), -10.1)
+        self.assertEqual(
+            parser.parse_input('10', float, tuple()), 10.0
+        )
+        self.assertEqual(
+            parser.parse_input(10, float, tuple()), 10.0
+        )
+        self.assertEqual(
+            parser.parse_input(10.1, float, tuple()), 10.1
+        )
+        self.assertEqual(
+            parser.parse_input(-10.1, float, tuple()), -10.1
+        )
+        self.assertEqual(
+            parser.parse_input('-10', float, tuple()), -10
+        )
+        self.assertEqual(
+            parser.parse_input('-10.1', float, tuple()), -10.1
+        )
 
 
 class TestDecimalParser(unittest.TestCase):
     def test_parses_int(self) -> None:
         parser: PavlovaParser = pavlova.parsers.DecimalParser(Pavlova())
 
-        self.assertEqual(parser.parse_input('10', Decimal), Decimal('10'))
-        self.assertEqual(parser.parse_input(10, Decimal), Decimal('10.0'))
-        self.assertTrue(
-            Decimal('10') < parser.parse_input(10.1, Decimal) < Decimal('10.2')
+        self.assertEqual(
+            parser.parse_input('10', Decimal, tuple()), Decimal('10')
         )
-        self.assertEqual(parser.parse_input('-10', Decimal), Decimal('-10'))
-        self.assertEqual(parser.parse_input('-10.1', Decimal), Decimal('-10.1'))
+        self.assertEqual(
+            parser.parse_input(10, Decimal, tuple()), Decimal('10.0')
+        )
+        self.assertTrue(
+            Decimal('10') <
+            parser.parse_input(10.1, Decimal, tuple()) <
+            Decimal('10.2')
+        )
+        self.assertEqual(
+            parser.parse_input('-10', Decimal, tuple()), Decimal('-10')
+        )
+        self.assertEqual(
+            parser.parse_input('-10.1', Decimal, tuple()), Decimal('-10.1')
+        )
 
 
 class SampleEnum(Enum):
@@ -179,12 +213,22 @@ class TestEnumParser(unittest.TestCase):
     def test_parses_string(self) -> None:
         parser: PavlovaParser = pavlova.parsers.EnumParser(Pavlova())
 
-        self.assertEqual(parser.parse_input('red', SampleEnum), SampleEnum.RED)
-        self.assertEqual(parser.parse_input('RED', SampleEnum), SampleEnum.RED)
-        self.assertEqual(parser.parse_input('gReEn', SampleEnum), SampleEnum.GREEN)
+        self.assertEqual(
+            parser.parse_input('red', SampleEnum, tuple()), SampleEnum.RED
+        )
+        self.assertEqual(
+            parser.parse_input('RED', SampleEnum, tuple()), SampleEnum.RED
+        )
+        self.assertEqual(
+            parser.parse_input('gReEn', SampleEnum, tuple()), SampleEnum.GREEN
+        )
 
     def test_parses_enum_value(self) -> None:
         parser: PavlovaParser = pavlova.parsers.EnumParser(Pavlova())
 
-        self.assertEqual(parser.parse_input(1, SampleEnum), SampleEnum.RED)
-        self.assertEqual(parser.parse_input(2, SampleEnum), SampleEnum.GREEN)
+        self.assertEqual(
+            parser.parse_input(1, SampleEnum, tuple()), SampleEnum.RED
+        )
+        self.assertEqual(
+            parser.parse_input(2, SampleEnum, tuple()), SampleEnum.GREEN
+        )

--- a/tests/test_pavlova.py
+++ b/tests/test_pavlova.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional
 
 from dataclasses import dataclass
 
-from pavlova import Pavlova
+from pavlova import Pavlova, PavlovaParsingError
 
 
 class SampleEnum(Enum):
@@ -33,6 +33,11 @@ class Sample:
     locations: List[str]
     country: Optional[str]
     nested: Optional[NestedSample] = None
+
+
+@dataclass
+class SimpleSample:
+    value: List[int]
 
 
 class TestPavlova(unittest.TestCase):
@@ -75,3 +80,25 @@ class TestPavlova(unittest.TestCase):
         self.assertTrue(isinstance(parsed, Nested))
         self.assertTrue(isinstance(parsed.nested, NestedSample))
         self.assertEqual(parsed.nested.key, 'locked')
+
+    def test_value_error_causes_error(self) -> None:
+        pavlova = Pavlova()
+        with self.assertRaises(PavlovaParsingError) as raised:
+            pavlova.from_mapping({
+                'value': ['bob'],
+            }, SimpleSample)
+
+        exc = raised.exception
+        self.assertTrue(isinstance(exc.original_exception, ValueError))
+        self.assertEqual(exc.path, ('value',))
+
+    def test_type_error_causes_error(self) -> None:
+        pavlova = Pavlova()
+        with self.assertRaises(PavlovaParsingError) as raised:
+            pavlova.from_mapping({
+                'value': 'bob',
+            }, SimpleSample)
+
+        exc = raised.exception
+        self.assertTrue(isinstance(exc.original_exception, TypeError))
+        self.assertEqual(exc.path, ('value',))


### PR DESCRIPTION
This allows you to catch a single exception in a global error handler, and handle parsing issues.

This will also give you context over where the exception occurred. If you only had the original TypeError and ValueError exceptions, there isn't enough information to tell you where in the content the error occurred.