### PR TITLE
Remove checking for a validation field on the dataclass

### DIFF
--- a/pavlova/__init__.py
+++ b/pavlova/__init__.py
@@ -103,21 +103,6 @@ class Pavlova(BasePavlova):
                     field.type,
                 )
 
-            try:
-                if field.metadata and 'validator' in field.metadata:
-                    if not field.metadata['validator'](data[field.name]):
-                        raise ValueError(
-                            f'{data[field.name]} is not a '
-                            f' valid value for {field.type}'
-                        )
-            except ValueError as exc:
-                raise PavlovaParsingError(
-                    str(exc),
-                    exc,
-                    path + (field.name,),
-                    field.type,
-                )
-
         return model_class(**data)  # type: ignore
 
     def parse_field(self,

--- a/pavlova/parsers.py
+++ b/pavlova/parsers.py
@@ -184,3 +184,15 @@ class EnumParser(PavlovaParser[Enum]):
 
         # Try instantiating the enum with our value
         return field_type(input_value)
+
+
+class GenericParser(PavlovaParser[T]):
+    def __init__(self, pavlova: BasePavlova, parser_type: T) -> None:
+        super().__init__(pavlova)
+        self.parser_type = parser_type
+
+    def parse_input(self,
+                    input_value: Any,
+                    field_type: Type,
+                    path: Tuple[str, ...]) -> T:
+        return self.parser_type(input_value)  # type: ignore

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,12 @@
+# pylint: disable=missing-docstring
+
+from typing import Any
+
+
+class Email(str):
+    def __new__(cls, input_value: Any) -> str:
+        if isinstance(input_value, str):
+            if '@' in input_value:
+                return str(input_value)
+            raise ValueError()
+        raise TypeError()

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -9,6 +9,7 @@ from typing import List, Dict, Union, Optional
 from pavlova import Pavlova
 import pavlova.parsers
 from pavlova.parsers import PavlovaParser
+from tests import Email
 
 
 class TestBoolParser(unittest.TestCase):
@@ -232,3 +233,16 @@ class TestEnumParser(unittest.TestCase):
         self.assertEqual(
             parser.parse_input(2, SampleEnum, tuple()), SampleEnum.GREEN
         )
+
+
+class TestGenericParser(unittest.TestCase):
+    def test_calls_generic_type(self) -> None:
+
+        parser = pavlova.parsers.GenericParser(Pavlova(), Email)
+        self.assertEqual(
+            parser.parse_input('chris@chris', Email, tuple()),
+            'chris@chris',
+        )
+
+        with self.assertRaises(ValueError):
+            parser.parse_input('chris', Email, tuple())

--- a/tests/test_pavlova.py
+++ b/tests/test_pavlova.py
@@ -9,6 +9,8 @@ from typing import Dict, List, Optional
 from dataclasses import dataclass
 
 from pavlova import Pavlova, PavlovaParsingError
+from pavlova.parsers import GenericParser
+from tests import Email
 
 
 class SampleEnum(Enum):
@@ -102,3 +104,18 @@ class TestPavlova(unittest.TestCase):
         exc = raised.exception
         self.assertTrue(isinstance(exc.original_exception, TypeError))
         self.assertEqual(exc.path, ('value',))
+
+    def test_with_generic_parser(self) -> None:
+        @dataclass
+        class Example:
+            email: Email
+
+        pavlova = Pavlova()
+        pavlova.register_parser(Email, GenericParser(pavlova, Email))
+        pavlova.from_mapping({'email': 'chris@chris.com'}, Example)
+
+        with self.assertRaises(PavlovaParsingError):
+            pavlova.from_mapping({'email': 'chris'}, Example)
+
+        with self.assertRaises(PavlovaParsingError):
+            pavlova.from_mapping({'email': 123}, Example)


### PR DESCRIPTION
This remove support for setting a validation function on the dataclass.

What users should do instead is create their own type, and subclass the underlying type, and do their validation in either the `__new__` or `__init__` function.

For example, here is a simple Email type.
```
class Email(str):
    def __new__(cls, input_value: Any) -> str:
        if isinstance(input_value, str):
            if '@' in input_value:
                return str(input_value)
            raise ValueError()
        raise TypeError()
```

I believe this change makes it easier for users to understand what is being validated, and what the underlying types actually mean.

It also allows you to use these types elsewhere, not just within Pavlova and introduce more strictness in your code.