### PR TITLE
Support parsing of query string and body in the same request

### DIFF
--- a/pavlova/flask.py
+++ b/pavlova/flask.py
@@ -28,7 +28,14 @@ class FlaskPavlova(Pavlova):
         return _wrapper
 
     def _from_flask_request(self, model_class: Type[T]) -> T:
+        json_body: Dict[str, Any] = {}
         if flask.request.is_json:
-            return self.from_mapping(flask.request.get_json(), model_class)
+            json_body = flask.request.get_json()
 
-        return self.from_mapping(flask.request.values, model_class)
+        return self.from_mapping(
+            {
+                **json_body,
+                **flask.request.values.to_dict()
+            },
+            model_class
+        )

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -12,6 +12,7 @@ from pavlova.flask import FlaskPavlova
 @dataclass
 class InputSample:
     id: int
+    category: str
 
 
 class TestFlaskPavlova(unittest.TestCase):
@@ -30,24 +31,45 @@ class TestFlaskPavlova(unittest.TestCase):
 
     def test_post_with_json(self) -> None:
         with self.app.test_client() as client:
-            client.post('/', json={'id': 10})
+            client.post('/', json={'id': 10, 'category': 'doggo'})
 
         assert self.input_sample is not None
         self.assertTrue(isinstance(self.input_sample, InputSample))
         self.assertEqual(self.input_sample.id, 10)
+        self.assertEqual(self.input_sample.category, 'doggo')
 
     def test_post_with_args(self) -> None:
         with self.app.test_client() as client:
-            client.post('/?id=10')
+            client.post('/?id=10&category=doggo')
 
         assert self.input_sample is not None
         self.assertTrue(isinstance(self.input_sample, InputSample))
         self.assertEqual(self.input_sample.id, 10)
+        self.assertEqual(self.input_sample.category, 'doggo')
 
     def test_post_with_form_data(self) -> None:
         with self.app.test_client() as client:
-            client.post('/', data={'id': 10})
+            client.post('/', data={'id': 10, 'category': 'doggo'})
 
         assert self.input_sample is not None
         self.assertTrue(isinstance(self.input_sample, InputSample))
         self.assertEqual(self.input_sample.id, 10)
+        self.assertEqual(self.input_sample.category, 'doggo')
+
+    def test_post_with_args_and_json(self) -> None:
+        with self.app.test_client() as client:
+            client.post('/?category=doggo', json={'id': 10})
+
+        assert self.input_sample is not None
+        self.assertTrue(isinstance(self.input_sample, InputSample))
+        self.assertEqual(self.input_sample.id, 10)
+        self.assertEqual(self.input_sample.category, 'doggo')
+
+    def test_post_with_args_and_form_data(self) -> None:
+        with self.app.test_client() as client:
+            client.post('/?category=doggo', data={'id': 10})
+
+        assert self.input_sample is not None
+        self.assertTrue(isinstance(self.input_sample, InputSample))
+        self.assertEqual(self.input_sample.id, 10)
+        self.assertEqual(self.input_sample.category, 'doggo')


### PR DESCRIPTION
This diff merges the results from `get_json` (if applicable) and `flask.request.values` to enable support for incoming requests that has both a body and query string.